### PR TITLE
line and bar graph internationalization

### DIFF
--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -12,6 +12,7 @@ import { State } from '../types/redux/state';
 import { preferencesApi } from '../utils/api';
 import translate from '../utils/translate';
 import { LanguageTypes } from '../types/i18n';
+import moment = require('moment');
 
 
 export function updateSelectedMeter(meterID: number): t.UpdateImportMeterAction {
@@ -31,6 +32,7 @@ export function toggleDefaultBarStacking(): t.ToggleDefaultBarStackingAction {
 }
 
 export function updateDefaultLanguage(defaultLanguage: LanguageTypes): t.UpdateDefaultLanguageAction {
+	moment.locale(defaultLanguage);
 	return { type: ActionType.UpdateDefaultLanguage, defaultLanguage };
 }
 

--- a/src/client/app/containers/BarChartContainer.ts
+++ b/src/client/app/containers/BarChartContainer.ts
@@ -8,6 +8,8 @@ import { connect } from 'react-redux';
 import getGraphColor from '../utils/getGraphColor';
 import { State } from '../types/redux/state';
 import PlotlyChart, { IPlotlyChartProps } from 'react-plotlyjs-ts';
+import * as es from 'plotly.js/lib/locales/es'
+import * as fr from 'plotly.js/lib/locales/fr'
 
 function mapStateToProps(state: State) {
 	const timeInterval = state.graph.timeInterval;
@@ -131,10 +133,15 @@ function mapStateToProps(state: State) {
 		data: datasets,
 		layout,
 		config: {
-			displayModeBar: false
+			displayModeBar: false,
+			locales: {'es':es,'fr':fr} //makes languages available for use
 		}
 	};
-
+	const lang = state.admin.defaultLanguage;
+	if(lang == 'fr')
+		props.config.locale = 'fr'
+	else if(lang == 'es')
+		props.config.locale = 'es'
 	return props;
 }
 

--- a/src/client/app/containers/LineChartContainer.ts
+++ b/src/client/app/containers/LineChartContainer.ts
@@ -9,6 +9,8 @@ import getGraphColor from '../utils/getGraphColor';
 import { State } from '../types/redux/state';
 import PlotlyChart, { IPlotlyChartProps } from 'react-plotlyjs-ts';
 import {TimeInterval} from '../../../common/TimeInterval';
+import * as es from 'plotly.js/lib/locales/es'
+import * as fr from 'plotly.js/lib/locales/fr'
 
 function mapStateToProps(state: State) {
 	const timeInterval = state.graph.timeInterval;
@@ -152,10 +154,15 @@ function mapStateToProps(state: State) {
 		data: datasets,
 		layout,
 		config: {
-			displayModeBar: true
+			displayModeBar: true,
+			locales: {'es':es,'fr':fr} //makes languages available for use
 		}
 	};
-
+	const lang = state.admin.defaultLanguage;
+	if(lang == 'fr')
+		props.config.locale = 'fr'
+	else if(lang == 'es')
+		props.config.locale = 'es'
 	return props;
 }
 

--- a/src/client/app/types/json.d.ts
+++ b/src/client/app/types/json.d.ts
@@ -6,3 +6,11 @@ declare module '*.json' {
 	const value: any;
 	export default value;
 }
+declare module 'plotly.js/lib/locales/es'{
+	const value: any;
+	export default value;
+}
+declare module 'plotly.js/lib/locales/fr'{
+	const value: any;
+	export default value;
+}


### PR DESCRIPTION
The locale for moment.js is set globally on upon update of the user
preference (admin.ts)

However, the plotly localization must be set individually for each
PlotlyChart via its 'config' object.
(LineChartContainer.ts, BarChartContainer.ts)

Because the 'noImplicitAny' flag is set to true, the Plotly
localizations must be declared as modules.
TODO: find a better place for these declarations or rename
the file
(json.d.ts)